### PR TITLE
fix: simplified category/folder setup broke colab buttons

### DIFF
--- a/themes/mg/templates/collab-link.html
+++ b/themes/mg/templates/collab-link.html
@@ -1,6 +1,6 @@
 <!-- <a class="collab-link" href="https://colab.research.google.com/github/computableai/computableai.github.io/blob/dev/{{article.source_path.split('/')[-3:] | join('/') }}"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab" title="Open in Google Colaboratory"></a> -->
 
-<a class="collab-link" href="https://colab.research.google.com/github/computableai/computableai.github.io/blob/dev/{{article.source_path.split('/')[-3:] | join('/') }}">
+<a class="collab-link" href="https://colab.research.google.com/github/computableai/computableai.github.io/blob/dev/{{article.source_path.split('/')[-2:] | join('/') }}">
   Open in Colab
   
   <svg width="26px" height="26px" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
I've fixed this by changing how much of the source file path gets pulled into the colab URL.