### PR TITLE
fix: fix cause of improper spacing between text cells

### DIFF
--- a/themes/mg/static/css/articles.css
+++ b/themes/mg/static/css/articles.css
@@ -116,6 +116,7 @@
   font-size: var(--font-size-text-lg);
   line-height: var(--line-height-loose);
   margin-bottom: 10rem;
+  max-width: 65ch;
 }
 
 
@@ -123,16 +124,26 @@
 
 .article-body p {
   margin: 1em 0 0;
-  max-width: 65ch;
 }
 
+.article-body h1,
 .article-body h2,
 .article-body h3,
 .article-body h4,
 .article-body h5,
 .article-body h6 {
+  margin-top: 2em;
   font-weight: var(--font-weight-semibold);
   letter-spacing: 0.015ch;
+}
+
+.article-body blockquote {
+  padding-left: 1rem;
+  border-left: 2px solid;
+  line-height: inherit;
+  font-size: inherit;
+  font-style: italic;
+  color: var(--color-content-muted);
 }
 
 


### PR DESCRIPTION
- Fixes #11 
- Add margin to top of article top-level headings
- Make margins consistent between all article headings
---

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/98312/61172942-fbff5d80-a559-11e9-9799-4dcc7c35d65e.png">


Also...
- Move content max-width to article-level instead of article children to make proper use of "Character" length unit (heading characters are larger than paragraph characters, leading to inconsistent element widths inside articles)
- Tweak blockquote styles to be more consistent with context