### PR TITLE
fix: add missing author name to article meta

### DIFF
--- a/themes/mg/templates/article.html
+++ b/themes/mg/templates/article.html
@@ -47,7 +47,9 @@
       <header class="article-header">
         <h1 class="uk-heading-large uk-article-title" itemprop="name">{{ article.title }}</h1>
         <p class="uk-article-lead" itemprop="description">{{ article.summary|striptags }}</p>
-        <p class="uk-article-meta"><time datetime="{{ article.date.strftime('%Y-%m-%d') }}" itemprop="datePublished">{{ article.locale_date }}</time> in <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>{% if DISQUS_SITENAME %} • <br class="uk-visible-small"> <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread" itemprop="discussionUrl"></a>{% endif %}</p>
+        <p class="uk-article-meta">
+            {% if article.author %}<span class="uk-author">{{ article.author }}</span> • {% endif %}
+          <time datetime="{{ article.date.strftime('%Y-%m-%d') }}" itemprop="datePublished">{{ article.locale_date }}</time> in <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a>{% if DISQUS_SITENAME %} • <br class="uk-visible-small"> <a href="{{ SITEURL }}/{{ article.url }}#disqus_thread" itemprop="discussionUrl"></a>{% endif %}</p>
         {% include 'collab-link.html' %}
       </header>
 


### PR DESCRIPTION
- Adds missing author name
- Fixes #13 

<img width="284" alt="image" src="https://user-images.githubusercontent.com/98312/61172965-539dc900-a55a-11e9-9526-fe60e1a813f3.png">
