### PR TITLE
feat: better alignment for input prompt markers

### DIFF
--- a/themes/mg/static/css/articles.css
+++ b/themes/mg/static/css/articles.css
@@ -122,7 +122,8 @@
 
 /* Article Typography */
 
-.article-body p {
+.article-body p,
+.article-body pre {
   margin: 1em 0 0;
 }
 
@@ -167,6 +168,35 @@
 .article-body .MathJax .mi,
 .article-body .MathJax .mn {
   color: inherit !important;
+}
+
+
+/* Code */
+.article-body .input {
+  position: relative;
+}
+
+.article-body .input .highlight {
+  background: inherit;
+  color: inherit;
+}
+
+.article-body .input_prompt {
+  float: left;
+  font-size: var(--font-size-text-sm);
+  font-family: var(--font-stack-code);
+  margin: 0 1rem 0 0;
+}
+
+@media all and (min-width: 85em) {
+  .article-body .input_prompt {
+    text-align: right;
+    position: absolute;
+    right: calc(100% + 1em);
+    top: 0;
+    float: none;
+  }
+
 }
 
 


### PR DESCRIPTION
Closes #30 

- Aligns them off to the left of the text on large screens
<img width="817" alt="image" src="https://user-images.githubusercontent.com/98312/67162418-cd9bd600-f331-11e9-9a63-27d09162fc01.png">

- Floats them into the column on smaller screens. This presses the `pre` content in a bit as well.
<img width="703" alt="image" src="https://user-images.githubusercontent.com/98312/67162425-dab8c500-f331-11e9-8c6b-1fa44d2ecbda.png">
