### PR TITLE
Remove feature branch from publish workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish site
 
 on:
   push:
-    branches: [dev, claude/computable-ai-repo-update-x9j1i7]
+    branches: [dev]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Post-merge cleanup for #56: the feature branch was in the workflow's push triggers only to validate the render pipeline on CI before switching over. Now that the migration is merged and deployed, restrict the trigger back to `dev`. The `if: github.ref == 'refs/heads/dev'` gate on the deploy step stays as a safety measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXdH68Zgh99MDTF5Cpkn7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXdH68Zgh99MDTF5Cpkn7q)_