### PR TITLE
Drop categories from the listing; update tagline

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -5,16 +5,16 @@ listing:
   contents: posts
   sort: "date desc"
   type: default
-  categories: true
+  categories: false
   sort-ui: false
   filter-ui: true
   feed: true
-  fields: [image, date, title, description, categories, reading-time]
+  fields: [image, date, title, description, reading-time]
 page-layout: full
 title-block-banner: false
 toc: false
 ---
 
 ::: {.site-tagline}
-A machine intelligence blog — notes on deep reinforcement learning, probability, and the mathematics of learning machines.
+A personal blog on machine intelligence, probability, and whatever else.
 :::


### PR DESCRIPTION
- Remove the Categories sidebar and the per-card category chips from the home listing (`categories: false`, chips dropped from listing fields). Posts keep their front-matter categories harmlessly.
- Update the tagline to "A personal blog on machine intelligence, probability, and whatever else."

Merging deploys to computable.ai automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXdH68Zgh99MDTF5Cpkn7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXdH68Zgh99MDTF5Cpkn7q)_